### PR TITLE
Using sync-request insted of httpsync

### DIFF
--- a/httprequire.js
+++ b/httprequire.js
@@ -24,9 +24,8 @@ var _eval = function(data) {
 		if ( !_isEmpty(exports) && _isEmpty(module.exports) )
 			module.exports = exports;
 	})();
-
+	
 	return module.exports;
-
 };
 
 
@@ -38,13 +37,12 @@ var _syncRequire = function(url,force) {
 		return _cache[url];
 
 	var
-		httpsync = require('httpsync'),
-		req = httpsync.get({url: url}),
-		res = req.end(),
-		data = res.data.toString();
+		request = require('sync-request'),
+		req = request("GET", url),
+		data = req.getBody().toString();
 
 	if ( !data ) {
-		console.log("Got no data. Status was: "+res.status);
+		console.log("Got no data.");
 		return null;
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "./httprequire",
   "bin": { },
   "dependencies": {
-     "httpsync": ">= 0.0.7"
+     "sync-request": "2.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
sync-request is a little slower but work on Windows, which httpsync
don't
